### PR TITLE
set input value to zero if undefined

### DIFF
--- a/web/src/Components/Combinations/CombinationTable.tsx
+++ b/web/src/Components/Combinations/CombinationTable.tsx
@@ -44,6 +44,9 @@ export const CombinationTable = ({
   }, [productsInCombination, setPercentages, allProducts])
 
   const handleValueChange = (productId: string, value: string) => {
+    if (!value) {
+      value = '0'
+    }
     if (parseInt(value) < 0) return
     let newValues: any = { ...values, [productId]: { value: parseInt(value), id: productId } }
     const newValuesWithPercentage = setPercentages(newValues, allProducts)


### PR DESCRIPTION
avoid api error message when pressing backspace inside input field by setting input value to zero if input value is undefined.