### PR TITLE
chore: Uppdate from v2 to v4. Fix docker compose syntax.

### DIFF
--- a/.github/workflows/on-push-prod.yaml
+++ b/.github/workflows/on-push-prod.yaml
@@ -1,6 +1,7 @@
 name: Algorithm-Report
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - prod

--- a/.github/workflows/on-push-prod.yaml
+++ b/.github/workflows/on-push-prod.yaml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@master
 
       - name: "Create report"
-        run: docker-compose build api && docker-compose run -u 0 api python src/tests/optimizer_test.py
+        run: docker compose build api && docker compose run -u 0 api python src/tests/optimizer_test.py
 
       - name: Archive results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: algorithm-report
           path: api/test_report.png


### PR DESCRIPTION
- Fixed docker compose syntax
- Uppdated `upload-artifact` action from v2 to v4