### PR TITLE
chore: Rework error handling for findDValue function.

### DIFF
--- a/web/src/Components/Bridging/InputContainer.tsx
+++ b/web/src/Components/Bridging/InputContainer.tsx
@@ -139,10 +139,26 @@ const InputContainer = ({
           <Typography variant="h3">Optimal Bridge:</Typography>
           <div style={{ marginInlineStart: '0.5rem' }}>
             {[10, 50, 90].map((d) => (
-              <p key={d}>
-                D{d}: {findDValue(optimalBridgeGraphData, d, 'Bridge')}
-                {'\u00B5m'}
-              </p>
+              <div key={d} style={{ display: 'flex', flexDirection: 'row' }}>
+                D{d}: {(() => {
+                  const value = findDValue(optimalBridgeGraphData, d, 'Bridge')
+                  return value === -1 ? (
+                    <span
+                      style={{
+                        paddingLeft: '0.5rem',
+                        color: 'red',
+                      }}
+                    >
+                      Input too big
+                    </span>
+                  ) : (
+                    <span style={{ paddingLeft: '0.5rem' }}>
+                      {value}
+                      {'\u00B5m'}
+                    </span>
+                  )
+                })()}
+              </div>
             ))}
           </div>
         </div>

--- a/web/src/Components/Combinations/CombinationCard.tsx
+++ b/web/src/Components/Combinations/CombinationCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Input, Switch, Tooltip } from '@equinor/eds-core-react'
+import { Button, Icon, Input, Switch, Tooltip, Typography } from '@equinor/eds-core-react'
 import { delete_to_trash, edit } from '@equinor/eds-icons'
 import { useContext, useEffect, useState } from 'react'
 import { AuthContext, type IAuthContext } from 'react-oauth2-code-pkce'
@@ -184,15 +184,15 @@ export const CombinationCard = ({
           <div style={{ borderTop: '1px solid', paddingTop: '3px' }}>
             <DValues>
               <div>D10</div>
-              <div>{D10}</div>
+              <div>{D10 === -1 ? <Typography style={{ color: 'red' }}>Can not compute values</Typography> : D10}</div>
             </DValues>
             <DValues>
               <div>D50</div>
-              <div>{D50}</div>
+              <div>{D50 === -1 ? <Typography style={{ color: 'red' }}>Can not compute values</Typography> : D50}</div>
             </DValues>
             <DValues>
               <div>D90</div>
-              <div>{D90}</div>
+              <div>{D90 === -1 ? <Typography style={{ color: 'red' }}>Can not compute values</Typography> : D90}</div>
             </DValues>
           </div>
         ) : (

--- a/web/src/Utils.ts
+++ b/web/src/Utils.ts
@@ -48,7 +48,9 @@ export function findDValue(graphData: GraphData[], goalYValue: number, bridgeNam
     }
     return false
   })
-  if (!indexOfClosestHigherYValue) throw new Error('Failed to find D-value of bridge')
+  if (!indexOfClosestHigherYValue) {
+    return -1
+  }
 
   // interpolate the values to get an approx value for the exact D requested
   return linearInterpolation(


### PR DESCRIPTION
In current version the UI brakes if too big numbers are entered. Currently the `findDValue` function throws an error resulting in a white page forcing the user to refresh the page and loose current progress. 

The changes made now returns the error instead, and checking the return type of the function to conditionally display errors to user if input is too big.

![image](https://github.com/user-attachments/assets/c640278b-30d3-426b-9230-5e6f99861afc)
