### PR TITLE
chore: update github actions + remove prod branch references

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -1,0 +1,12 @@
+name: "On PR updated"
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/on-push-master-branch.yaml
+++ b/.github/workflows/on-push-master-branch.yaml
@@ -1,17 +1,19 @@
-name: Algorithm-Report
-
+name: "Push to master branch"
 on:
   workflow_dispatch:
   push:
     branches:
-      - prod
+      - master
 
 permissions:
   contents: read
-  actions: write  
+  actions: write
 
 jobs:
-  test-report:
+  tests:
+    uses: ./.github/workflows/tests.yaml
+
+  build-test-report:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,8 +1,10 @@
-name: CI
-
-on: 
+name: "Test"
+on:
   workflow_dispatch:
+  workflow_call:
   push:
+    branches:
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
- Want to use Radix for promoting test to prod and remove the push to prod branch for production setting
- Want to run tests on pull request creation